### PR TITLE
allowing log output when options hasn't been defined

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
 language: node_js
 node_js:
-  - "0.10"
+  - 4
+  - 5
+  - 6
+  - 7

--- a/jasmine-phantomjs.js
+++ b/jasmine-phantomjs.js
@@ -107,7 +107,7 @@
       this.page = extend(this.page, {
 
         onConsoleMessage: function (message) {
-          if (self.options && !self.options.suppressConsole) {
+          if (!self.options || (self.options && !self.options.suppressConsole)) {
             return system.stdout.writeLine('[console] ' + message);
           }
         },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-jasmine-phantomjs",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "PhantomJS Runner for Jasmine 1.x",
   "keywords": [
     "phantomjs",


### PR DESCRIPTION
the code was suppressing log messages before window.__runner__.run was being called, which essentially made debugging impossible without editing the files in node_modules. this commit will allow logs to go through to stdout if the code hasn't set the options yet.